### PR TITLE
:surfer: Add answer for profiles-db service

### DIFF
--- a/rancher_pr_deploy.sh
+++ b/rancher_pr_deploy.sh
@@ -28,6 +28,7 @@ if [[ -n "$TRAVIS" ]]; then
     {
       echo "traefik_domain=dev.c2s.nhschoices.net"
       echo "profiles_docker_image_tag=pr-${TRAVIS_PULL_REQUEST}"
+      echo "profiles_db_docker_image_tag=latest"
       echo "splunk_hec_endpoint=https://splunk-collector.cloudapp.net:8088"
       echo "splunk_hec_token=${SPLUNK_HEC_TOKEN}"
       echo "hotjar_id=265857"


### PR DESCRIPTION
Creating this PR so the branch can be retrieved easily should it be deleted.

The branch is used by [nhsuk/profiles](https://github.com/nhsuk/profiles) whilst the work for sorting out the extended `answers.txt` file to include answers specific to the service is on-going.