### PR TITLE
:see_no_evil: Ignore generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Files generated when running script locally
+answers.txt
+docker-compose.yml
+rancher-compose.yml
+


### PR DESCRIPTION
In order to prevent the generated files being accidently checked in,
have them be ignored.