### PR TITLE
Apps Library specific ci scripts

### DIFF
--- a/gitlab/answers/10-defaults.sh
+++ b/gitlab/answers/10-defaults.sh
@@ -13,7 +13,7 @@
 if [ -n "${CI_COMMIT_TAG}" ]; then
   echo "DOCKER_IMAGE_TAG=${CI_COMMIT_TAG}" >> answers.txt
 # INTEGRATION BUILD
-elif [ "$CI_COMMIT_REF_SLUG" = "master" ]; then
+elif [ "$CI_COMMIT_REF_SLUG" = "master" -o "$CI_COMMIT_REF_SLUG" = "develop "]; then
   echo "DOCKER_IMAGE_TAG=latest" >> answers.txt
 else
   # IT'S A BRANCH

--- a/gitlab/answers/10-defaults.sh
+++ b/gitlab/answers/10-defaults.sh
@@ -13,7 +13,7 @@
 if [ -n "${CI_COMMIT_TAG}" ]; then
   echo "DOCKER_IMAGE_TAG=${CI_COMMIT_TAG}" >> answers.txt
 # INTEGRATION BUILD
-elif [ "$CI_COMMIT_REF_SLUG" = "master" -o "$CI_COMMIT_REF_SLUG" = "develop "]; then
+elif [ "$CI_COMMIT_REF_SLUG" = "master" -o "$CI_COMMIT_REF_SLUG" = "develop" ]; then
   echo "DOCKER_IMAGE_TAG=latest" >> answers.txt
 else
   # IT'S A BRANCH

--- a/gitlab/answers/20-vault-gitlab.sh
+++ b/gitlab/answers/20-vault-gitlab.sh
@@ -30,13 +30,8 @@ if [ -z "$VAULT_TOKEN" ]; then
 fi
 
 if [ "$SKIP" != "1" ]; then
-
-  if [ "$REVIEW_APP" == "TRUE" ]; then
-    ENVIRONMENT="review"
-  else
-    ENVIRONMENT="$CI_ENVIRONMENT_NAME"
-  fi
-
+  # Set the correct environment
+  ENVIRONMENT="$CI_ENVIRONMENT_NAME"
 
   # GET DEFAULT VARIABLES
   VAULT_PATH="/v1/secret/defaults"

--- a/gitlab/answers/30-branch-build.sh
+++ b/gitlab/answers/30-branch-build.sh
@@ -1,4 +1,4 @@
-if [ "$PROTOTYPE" == "TRUE" ]; then
+if [ "$BRANCH_BUILD" == "TRUE" ]; then
   {
     host="${CI_PROJECT_NAME//_/-}-${CI_COMMIT_REF_SLUG//_/-}"
     domain="dev.beta.nhschoices.net"

--- a/gitlab/answers/30-branch-build.sh
+++ b/gitlab/answers/30-branch-build.sh
@@ -1,6 +1,10 @@
 if [ "$BRANCH_BUILD" == "TRUE" ]; then
   {
-    host="${CI_PROJECT_NAME//_/-}-${CI_COMMIT_REF_SLUG//_/-}"
+    branch="${CI_COMMIT_REF_SLUG//_/-}"
+    if [ "${branch:0:5}" == "proto" ]; then
+      branch="prototype"
+    fi
+    host="${CI_PROJECT_NAME//_/-}-${branch}"
     domain="dev.beta.nhschoices.net"
     echo "DB_TYPE=sqlite"
     echo "TRAEFIK_RULE='Host: ${host}.${domain}'"

--- a/gitlab/answers/30-prototype.sh
+++ b/gitlab/answers/30-prototype.sh
@@ -1,8 +1,7 @@
 if [ "$PROTOTYPE" == "TRUE" ]; then
   {
-    host="${RANCHER_STACK_NAME//_/-}.${TRAEFIK_DOMAIN}"
     echo "DB_TYPE=sqlite"
-    echo 'TRAEFIK_RULE="Host: ${host}"'
-    echo "HOST_BETA=${host}"
+    echo "TRAEFIK_RULE='Host: ${RANCHER_STACK_NAME//_/-}.${TRAEFIK_DOMAIN}'"
+    echo "HOST_BETA=${RANCHER_STACK_NAME//_/-}.${TRAEFIK_DOMAIN}"
   } >> answers.txt
 fi

--- a/gitlab/answers/30-prototype.sh
+++ b/gitlab/answers/30-prototype.sh
@@ -1,7 +1,10 @@
 if [ "$PROTOTYPE" == "TRUE" ]; then
   {
+    host="${CI_PROJECT_NAME//_/-}-${CI_COMMIT_REF_SLUG//_/-}"
+    domain="dev.beta.nhschoices.net"
     echo "DB_TYPE=sqlite"
-    echo "TRAEFIK_RULE='Host: ${RANCHER_STACK_NAME//_/-}.${TRAEFIK_DOMAIN}'"
-    echo "HOST_BETA=${RANCHER_STACK_NAME//_/-}.${TRAEFIK_DOMAIN}"
+    echo "TRAEFIK_RULE='Host: ${host}.${domain}'"
+    echo "HOST_BETA=${host}.${domain}"
+    echo "DEPLOY_URL='${host}.${domain}'"
   } >> answers.txt
 fi

--- a/gitlab/answers/30-prototype.sh
+++ b/gitlab/answers/30-prototype.sh
@@ -1,6 +1,8 @@
 if [ "$PROTOTYPE" == "TRUE" ]; then
   {
+    host="${RANCHER_STACK_NAME//_/-}.${TRAEFIK_DOMAIN}"
     echo "DB_TYPE=sqlite"
-    echo 'TRAEFIK_RULE="Host: ${RANCHER_STACK_NAME}.${TRAEFIK_DOMAIN}"'
+    echo 'TRAEFIK_RULE="Host: ${host}"'
+    echo "HOST_BETA=${host}"
   } >> answers.txt
 fi

--- a/gitlab/answers/30-prototype.sh
+++ b/gitlab/answers/30-prototype.sh
@@ -1,0 +1,6 @@
+if [ "$PROTOTYPE" == "TRUE" ]; then
+  {
+    echo "DB_TYPE=sqlite"
+    echo 'TRAEFIK_RULE="Host: ${RANCHER_STACK_NAME}.${TRAEFIK_DOMAIN}"'
+  } >> answers.txt
+fi

--- a/gitlab/remove-review-app.sh
+++ b/gitlab/remove-review-app.sh
@@ -32,7 +32,7 @@ check_rancher_vars
 # Set RANCHER_URL, doing it here so we can set RANCHER_SERVER in Vault
 export RANCHER_URL=https://${RANCHER_SERVER}/v2-beta/schemas
 
-./rancher --wait rm "${RANCHER_STACK_NAME}"
+./rancher --wait rm "${RANCHER_STACK_NAME//_/-}"
 
 # RUN REPO SPECIFIC REMOVAL SCRIPTS, IF DIRECTORY EXISTS
 if [ -d "./scripts/removal_scripts" ]; then


### PR DESCRIPTION
The apps library uses a git-flow branching scheme, having feature branches based off the `develop` branch (which is used for integration testing).

The changes in this PR ensure that we can use `develop` in the same way as `master` is used by other projects that use this repository - however, as these changes are mostly apps library related, they only cover the GitLab CI pipeline, and so we remove the logic to handle 'review' branch builds as we neither have build steps nor review branches within the apps-library repository.