### PR TITLE
Delete answers.txt before building the docker image

### DIFF
--- a/common/generate-answers.sh
+++ b/common/generate-answers.sh
@@ -47,6 +47,3 @@ fi
 if [ "$SKIP_DEPLOY" = "true" ]; then
   echo "DEPLOY_BUILD=false" >> answers.txt
 fi
-
-# ENSURE answers.txt isn't in the Dockerfile!
-echo "answers.txt" >> .dockerignore

--- a/gitlab/build-docker-images.sh
+++ b/gitlab/build-docker-images.sh
@@ -10,6 +10,9 @@ set -o allexport
 source answers.txt
 set +o allexport
 
+# Delete answers.txt before building docker image to ensure secrets aren't leaked into the image
+rm answers.txt
+
 docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
 docker build -t "nhsuk/${CI_PROJECT_NAME}:${IMAGE_TAG}" .
 docker push "nhsuk/${CI_PROJECT_NAME}:${IMAGE_TAG}"

--- a/travis/build-docker-images.sh
+++ b/travis/build-docker-images.sh
@@ -78,6 +78,9 @@ if [ "$TAGS" != "" ]; then
   fold_start "Building_Default_Image"
   info "Building default image"
 
+  # Delete answers.txt before building docker image to ensure secrets aren't leaked into the image
+  rm answers.txt
+
   if docker build -t "${REPO_SLUG}" .; then
     info "Build succeeded."
   else


### PR DESCRIPTION
It might seem that adding "answers.txt" to the .dockerignore file would be enough to
prevent answers.txt from being built into the image, however:

1. If the .dockerignore file already exists and doesn't end in a newline, answers.txt is
added to the last line rather than being added as it's own line.

2. If there is no .dockerignore file, docker falls back to using the .gitignore file. This script
should not be creating a one-line .dockerignore file if one doesn't already exist.